### PR TITLE
Adapted changes from https://github.com/jc-m/libnetwork/tree/IPAliases

### DIFF
--- a/driverapi/driverapi.go
+++ b/driverapi/driverapi.go
@@ -103,6 +103,12 @@ type InterfaceInfo interface {
 
 	// AddressIPv6 returns the IPv6 address.
 	AddressIPv6() *net.IPNet
+
+	// IPAliases returns the list of IP aliases
+	IPAliases() []*net.IPNet
+
+	// SetIPAliases sets the list of IP aliases
+	SetIPAliases(aliases []*net.IPNet) error
 }
 
 // InterfaceNameInfo provides a go interface for the drivers to assign names

--- a/drivers/remote/api/api.go
+++ b/drivers/remote/api/api.go
@@ -71,6 +71,7 @@ type EndpointInterface struct {
 	Address     string
 	AddressIPv6 string
 	MacAddress  string
+	IPAliases   []string
 }
 
 // CreateEndpointResponse is the response to the CreateEndpoint action.
@@ -84,6 +85,7 @@ type Interface struct {
 	Address     *net.IPNet
 	AddressIPv6 *net.IPNet
 	MacAddress  net.HardwareAddr
+	IPAliases   []*net.IPNet
 }
 
 // DeleteEndpointRequest describes the API for deleting an endpoint.

--- a/libnetwork_internal_test.go
+++ b/libnetwork_internal_test.go
@@ -172,6 +172,9 @@ func TestEndpointMarshalling(t *testing.T) {
 	}
 	nw6.IP = ip
 
+	alias1 := &net.IPNet{IP: net.IP{8, 8, 8, 8}, Mask: net.IPMask{255, 255, 255, 255}}
+	alias2 := &net.IPNet{IP: net.IP{9, 9, 9, 9}, Mask: net.IPMask{255, 255, 255, 255}}
+
 	e := &endpoint{
 		name:      "Bau",
 		id:        "efghijklmno",
@@ -188,6 +191,10 @@ func TestEndpointMarshalling(t *testing.T) {
 			dstPrefix: "eth",
 			v4PoolID:  "poolpool",
 			v6PoolID:  "poolv6",
+			ipAliases: []*net.IPNet{
+				alias1,
+				alias2,
+			},
 		},
 	}
 
@@ -207,6 +214,27 @@ func TestEndpointMarshalling(t *testing.T) {
 	}
 }
 
+func compareIPNetSlice(a, b []*net.IPNet) bool {
+	var found bool
+
+	if len(a) != len(b) {
+		return false
+	}
+	for _, x := range a {
+		found = false
+		for _, y := range b {
+			if types.CompareIPNet(x, y) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
 func compareEndpointInterface(a, b *endpointInterface) bool {
 	if a == b {
 		return true
@@ -215,7 +243,7 @@ func compareEndpointInterface(a, b *endpointInterface) bool {
 		return false
 	}
 	return a.srcName == b.srcName && a.dstPrefix == b.dstPrefix && a.v4PoolID == b.v4PoolID && a.v6PoolID == b.v6PoolID &&
-		types.CompareIPNet(a.addr, b.addr) && types.CompareIPNet(a.addrv6, b.addrv6)
+		types.CompareIPNet(a.addr, b.addr) && types.CompareIPNet(a.addrv6, b.addrv6) && compareIPNetSlice(a.ipAliases, b.ipAliases)
 }
 
 func compareIpamConfList(listA, listB []*IpamConf) bool {

--- a/sandbox.go
+++ b/sandbox.go
@@ -850,6 +850,9 @@ func (sb *sandbox) populateNetworkResources(ep *endpoint) error {
 			vipAlias := &net.IPNet{IP: ep.virtualIP, Mask: net.CIDRMask(32, 32)}
 			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().IPAliases([]*net.IPNet{vipAlias}))
 		}
+		if i.ipAliases != nil {
+			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().IPAliases(i.ipAliases))
+		}
 		if i.mac != nil {
 			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().MacAddress(i.mac))
 		}


### PR DESCRIPTION
Adapting changes proposed in https://github.com/jc-m/libnetwork/tree/IPAliases to support adding IP aliases to network interfaces inside containers.
