### PR TITLE
17.12 medallia fix arp table

### DIFF
--- a/cmd/ovrouter/ovrouter.go
+++ b/cmd/ovrouter/ovrouter.go
@@ -46,6 +46,10 @@ func (ep *endpoint) SetExtraIPAddresses(addresses []*net.IPNet) error {
 	return nil
 }
 
+func (ep *endpoint) SetLinkLocalIPAddress(address *net.IPNet) error {
+	return nil
+}
+
 func (ep *endpoint) SetMacAddress(mac net.HardwareAddr) error {
 	if ep.mac != nil {
 		return types.ForbiddenErrorf("endpoint interface MAC address present (%s). Cannot be modified with %s.", ep.mac, mac)

--- a/driverapi/driverapi.go
+++ b/driverapi/driverapi.go
@@ -112,6 +112,9 @@ type InterfaceInfo interface {
 	// Assign extra IP addresses
 	SetExtraIPAddresses(ips []*net.IPNet) error
 
+	// Assign link-local address
+	SetLinkLocalIPAddress(ip *net.IPNet) error
+
 	// MacAddress returns the MAC address.
 	MacAddress() net.HardwareAddr
 

--- a/drivers/routed/routed.go
+++ b/drivers/routed/routed.go
@@ -206,7 +206,7 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 	for i := range ipv4Addresses {
 		addresses[i] = netlink.Addr{IPNet: &ipv4Addresses[i]}
 		ips[i] = &ipv4Addresses[i]
-	} http.ResponseWriter, r *http.Request
+	}
 
 	localLinkIp, _ := netlink.ParseIPNet(sandboxLinkLocalAddress)
 	addresses = append(addresses, netlink.Addr{IPNet: localLinkIp, Scope: unix.RT_SCOPE_LINK})

--- a/drivers/routed/routed.go
+++ b/drivers/routed/routed.go
@@ -15,6 +15,8 @@ import (
 	"github.com/docker/libnetwork/netutils"
 	"github.com/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -22,7 +24,7 @@ const (
 	ifaceID     = 1
 	defaultMtu  = 9000
 	vethPrefix  = "vethr"
-	sandboxLinkLocallAddress = "169.254.0.2/30"
+	sandboxLinkLocalAddress = "169.254.0.2/30"
 	defaultGw               = "169.254.0.1/30"
 )
 

--- a/endpoint_info.go
+++ b/endpoint_info.go
@@ -268,6 +268,14 @@ func (epi *endpointInterface) SetExtraIPAddresses(addresses []*net.IPNet) error 
 	return nil
 }
 
+func (epi *endpointInterface) SetLinkLocalIPAddress(address *net.IPNet) error {
+	logrus.Infof("Setting link-local IP address %s %s", epi.srcName, address)
+	a := make([]*net.IPNet, 0)
+	a = append(a, types.GetIPNetCopy(address))
+	epi.llAddrs = a
+	return nil
+}
+
 func setAddress(ifaceAddr **net.IPNet, address *net.IPNet) error {
 	if *ifaceAddr != nil {
 		return types.ForbiddenErrorf("endpoint interface IP present (%s). Cannot be modified with (%s).", *ifaceAddr, address)

--- a/osl/interface_linux.go
+++ b/osl/interface_linux.go
@@ -13,6 +13,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
+
+	"golang.org/x/sys/unix"
 )
 
 // IfaceOption is a function option type to set interface options
@@ -411,7 +413,7 @@ func setInterfaceIPv6(nlh *netlink.Handle, iface netlink.Link, i *nwIface) error
 
 func setInterfaceLinkLocalIPs(nlh *netlink.Handle, iface netlink.Link, i *nwIface) error {
 	for _, llIP := range i.LinkLocalAddresses() {
-		ipAddr := &netlink.Addr{IPNet: llIP}
+		ipAddr := &netlink.Addr{IPNet: llIP, Scope: unix.RT_SCOPE_LINK}
 		if err := nlh.AddrAdd(iface, ipAddr); err != nil {
 			return err
 		}


### PR DESCRIPTION
Changes:

- Add link local IP to all containers (169.254.0.2)
- Add default route to virtual gw (169.254.0.1) inside the containers

JIRA ticket [CIF-1516](https://jira.medallia.com/browse/CIF-1516)
Implements "The Hacky Solution: One-sided routing with Proxy-ARP" from [this doc](https://docs.google.com/document/d/1VWAhWg9spMCnBDmalvsGsvuB4fE8jzsRLi2Le2mHBso/edit#heading=h.1ygvun39kr1c)